### PR TITLE
this.state.uploadImageDataUrlには、プレビュー中の画像の元データを格納する

### DIFF
--- a/src/ImageHistory/ImageHistory.js
+++ b/src/ImageHistory/ImageHistory.js
@@ -1,22 +1,27 @@
 // @flow
 
+type ImageHistoryElem = {
+  originalData: string,
+  editedData: string,
+};
+
 export default class ImageHistory {
   constructor() {
     this.history = [];
     this.position = null;
   }
-  history: string[];
+  history: ImageHistoryElem[];
   position: number | null;
-  update(imageDataUrl: string) {
+  update(updateData: ImageHistoryElem) {
     if (this.position && this.position > 0) {
       this.history = this.history.filter(
         (e, index) => index >= ((this.position: any): number)
       );
     }
-    this.history.unshift(imageDataUrl);
+    this.history.unshift(updateData);
     this.position = 0;
   }
-  get(): string | null {
+  get(): ImageHistoryElem | null {
     if (this.history.length === 0 || this.position === null) return null;
     return this.history[this.position];
   }

--- a/src/ImageHistory/__tests__/ImageHistory.test.js
+++ b/src/ImageHistory/__tests__/ImageHistory.test.js
@@ -3,9 +3,9 @@ import assert from 'assert';
 import ImageHistory from '../ImageHistory';
 
 describe('ImageHistory', () => {
-  const stringAbc = 'abc';
-  const stringQwerty = 'qwerty';
-  const stringFoo = 'foo';
+  const abc = {originalData: 'abc', editedData: 'editedAbc'};
+  const qwerty = {originalData: 'qwerty', editedData: 'editedQwerty'};
+  const foo = {originalData: 'foo', editedData: 'editedQwerty'};
   let imageHistory;
   beforeEach(() => {
     imageHistory = new ImageHistory();
@@ -21,36 +21,36 @@ describe('ImageHistory', () => {
   });
   describe('update', () => {
     it('渡された引数が、historyの先頭の要素になる', () => {
-      imageHistory.update(stringAbc);
-      assert(imageHistory.history[0] === stringAbc);
-      imageHistory.update(stringQwerty);
-      assert(imageHistory.history[0] === stringQwerty);
+      imageHistory.update(abc);
+      assert(imageHistory.history[0].originalData === abc.originalData);
+      imageHistory.update(qwerty);
+      assert(imageHistory.history[0].originalData === qwerty.originalData);
     });
     it('positionが0になる', () => {
       imageHistory.position = 3;
       assert(imageHistory.position !== 0);
-      imageHistory.update(stringAbc);
+      imageHistory.update(abc);
       assert(imageHistory.position === 0);
     });
     it('position > 0 の場合、positionより前の要素は全て消去し前に詰める', () => {
-      imageHistory.update(stringAbc);
-      imageHistory.update(stringQwerty);
-      imageHistory.update(stringFoo);
+      imageHistory.update(abc);
+      imageHistory.update(qwerty);
+      imageHistory.update(foo);
       imageHistory.position = 2;
-      imageHistory.update(stringAbc);
+      imageHistory.update(abc);
       assert(imageHistory.history.length === 2);
-      assert(imageHistory.history[0] === stringAbc);
-      assert(imageHistory.history[1] === stringAbc);
+      assert(imageHistory.history[0].originalData === abc.originalData);
+      assert(imageHistory.history[1].originalData === abc.originalData);
     });
   });
   describe('get', () => {
     it('history[position]の要素を取得する', () => {
-      imageHistory.update(stringAbc);
-      imageHistory.update(stringQwerty);
+      imageHistory.update(abc);
+      imageHistory.update(qwerty);
       imageHistory.position = 1;
-      assert(imageHistory.get() === stringAbc);
+      assert(imageHistory.get().originalData === abc.originalData);
       imageHistory.position = 0;
-      assert(imageHistory.get() === stringQwerty);
+      assert(imageHistory.get().originalData === qwerty.originalData);
     });
     it('historyが空ならnullを返す', () => {
       assert(imageHistory.history.length === 0);
@@ -59,19 +59,19 @@ describe('ImageHistory', () => {
   });
   describe('back', () => {
     it('positionの数値を一つ増やす', () => {
-      imageHistory.update(stringAbc);
-      imageHistory.update(stringQwerty);
-      imageHistory.update(stringFoo);
+      imageHistory.update(abc);
+      imageHistory.update(qwerty);
+      imageHistory.update(foo);
       imageHistory.back();
       assert(imageHistory.position === 1);
       imageHistory.back();
       assert(imageHistory.position === 2);
     });
     it('(history.length - 1)よりは増えない', () => {
-      imageHistory.update(stringAbc);
+      imageHistory.update(abc);
       imageHistory.back();
       assert(imageHistory.position === 0);
-      imageHistory.update(stringQwerty);
+      imageHistory.update(qwerty);
       imageHistory.back();
       imageHistory.back();
       assert(imageHistory.position === 1);
@@ -85,9 +85,9 @@ describe('ImageHistory', () => {
   });
   describe('forward', () => {
     it('positionの数値を一つ減らす', () => {
-      imageHistory.update(stringAbc);
-      imageHistory.update(stringQwerty);
-      imageHistory.update(stringFoo);
+      imageHistory.update(abc);
+      imageHistory.update(qwerty);
+      imageHistory.update(foo);
       imageHistory.position = 2;
       imageHistory.forward();
       assert(imageHistory.position === 1);
@@ -95,14 +95,13 @@ describe('ImageHistory', () => {
       assert(imageHistory.position === 0);
     });
     it('0よりは減らない', () => {
-      imageHistory.update(stringAbc);
+      imageHistory.update(abc);
       imageHistory.position = 1;
       imageHistory.forward();
       assert(imageHistory.position === 0);
       imageHistory.forward();
       assert(imageHistory.position === 0);
     });
-    it('', () => {});
     it('historyが空なら何も起こらない', () => {
       assert(imageHistory.history.length === 0);
       assert(imageHistory.position === null);

--- a/src/components/ImageEditor.js
+++ b/src/components/ImageEditor.js
@@ -157,7 +157,10 @@ export default class ImageEditor extends React.Component<Props, State> {
     const historyData = imageHistory.get();
     if (!historyData) return;
     if (historyData.editedData === previewImageDataUrl) return;
-    this.setState({previewImageDataUrl: historyData.editedData});
+    this.setState({
+      previewImageDataUrl: historyData.editedData,
+      uploadImageDataUrl: historyData.originalData,
+    });
   }
 
   render() {

--- a/src/components/ImageEditor.js
+++ b/src/components/ImageEditor.js
@@ -108,13 +108,17 @@ export default class ImageEditor extends React.Component<Props, State> {
     this.generateUploadedImageCanvas()
       .then(res => taskList.reduce((canvas, task) => task(canvas), res))
       .then(res => {
-        const {fileMime} = this.state;
+        const {fileMime, uploadImageDataUrl} = this.state;
         if (!fileMime) throw new Error('fileMime is null.');
+        if (!uploadImageDataUrl) throw new Error('uploadImageDataUrl is null.');
         this.setState({
           previewImageDataUrl: res.toDataURL(fileMime),
           isProcessing: false,
         });
-        this.state.imageHistory.update(res.toDataURL(fileMime));
+        this.state.imageHistory.update({
+          originalData: uploadImageDataUrl,
+          editedData: res.toDataURL(fileMime),
+        });
       });
   }
 
@@ -130,10 +134,11 @@ export default class ImageEditor extends React.Component<Props, State> {
         ctx.drawImage(image, 0, 0, image.width, image.height);
         resolve(canvas);
       };
-      if (!this.state.uploadImageDataUrl) {
+      const {uploadImageDataUrl} = this.state;
+      if (!uploadImageDataUrl) {
         throw new Error('uploadImageDataUrl is null');
       }
-      image.src = this.state.uploadImageDataUrl;
+      image.src = uploadImageDataUrl;
     });
   }
 
@@ -149,9 +154,10 @@ export default class ImageEditor extends React.Component<Props, State> {
   showImageFromImageHistory: Function;
   showImageFromImageHistory() {
     const {previewImageDataUrl, imageHistory} = this.state;
-    const targetImage = imageHistory.get();
-    if (targetImage === previewImageDataUrl) return;
-    this.setState({previewImageDataUrl: targetImage});
+    const historyData = imageHistory.get();
+    if (!historyData) return;
+    if (historyData.editedData === previewImageDataUrl) return;
+    this.setState({previewImageDataUrl: historyData.editedData});
   }
 
   render() {


### PR DESCRIPTION
常に、プレビュー中の画像の元データに対して変更を加えるようにするため。
今までは、historyの先頭に入っている画像の元データに対して変更を加えてしまうという挙動だった。