### PR TITLE
画面がスクロールしていても ActionLayer の座標を正しく取得できるようにする

### DIFF
--- a/src/components/actionLayer/MouseMoveActionLayer.js
+++ b/src/components/actionLayer/MouseMoveActionLayer.js
@@ -39,7 +39,7 @@ export default class MouseMoveActionLayer extends React.Component<
     };
     this.canvas = null;
     this.ctx = null;
-    this.canvasStartPosition = null;
+    this.canvasStartPosition = {x: null, y: null};
   }
   componentDidMount() {
     const {canvas} = this;
@@ -59,38 +59,38 @@ export default class MouseMoveActionLayer extends React.Component<
     this.props.callbackDidUpdate({ctx});
   }
   setStartPoint(mouseEventPageX: number, mouseEventPageY: number) {
-    const {canvasStartPosition} = this;
-    if (!canvasStartPosition) throw new Error('canvasStartPosition is null.');
+    const {x, y} = this.canvasStartPosition;
+    if (!x || !y) throw new Error('canvasStartPosition is null.');
     this.setState({
       startPoint: {
-        x: mouseEventPageX - canvasStartPosition.x,
-        y: mouseEventPageY - canvasStartPosition.y,
+        x: mouseEventPageX - x,
+        y: mouseEventPageY - y,
       },
     });
   }
   getCurrentPoint(mouseEventPageX: number, mouseEventPageY: number): Point {
-    const {canvasStartPosition} = this;
-    if (!canvasStartPosition) throw new Error('canvasStartPosition is null.');
+    const {x, y} = this.canvasStartPosition;
+    if (!x || !y) throw new Error('canvasStartPosition is null.');
     return {
-      x: mouseEventPageX - canvasStartPosition.x,
-      y: mouseEventPageY - canvasStartPosition.y,
+      x: mouseEventPageX - x,
+      y: mouseEventPageY - y,
     };
   }
   loadContextSetting(ctx: CanvasRenderingContext2D) {
     Object.assign(ctx, this.props.setting.ctx);
   }
   isOutsideDisplay(mouseEventPageX: number, mouseEventPageY: number): boolean {
-    const {canvasStartPosition} = this;
-    if (!canvasStartPosition) throw new Error('canvasStartPosition is null.');
-    const x = mouseEventPageX - canvasStartPosition.x;
-    const y = mouseEventPageY - canvasStartPosition.y;
+    const {x, y} = this.canvasStartPosition;
+    if (!x || !y) throw new Error('canvasStartPosition is null.');
+    const targetX = mouseEventPageX - x;
+    const targetY = mouseEventPageY - y;
     const {width, height} = this.props.display;
-    return x > width || y > height;
+    return targetX > width || targetY > height;
   }
 
   canvas: HTMLCanvasElement | null;
   ctx: CanvasRenderingContext2D | null;
-  canvasStartPosition: Point | null;
+  canvasStartPosition: {x: number | null, y: number | null};
 
   startAction() {
     this.props.startOmitLengthCount();

--- a/src/components/actionLayer/MouseMoveActionLayer.js
+++ b/src/components/actionLayer/MouseMoveActionLayer.js
@@ -45,13 +45,13 @@ export default class MouseMoveActionLayer extends React.Component<
     const {canvas} = this;
     if (!canvas) throw new Error('canvas is null.');
     this.ctx = canvas.getContext('2d');
-    const {x, y} = ((canvas.getBoundingClientRect(): any): DOMRect);
+    const {left, top} = ((canvas.getBoundingClientRect(): any): DOMRect);
     if (!document.scrollingElement) {
       throw new Error('document.scrollingElement is undefined.');
     }
     const {scrollTop, scrollLeft} = (document.scrollingElement: any);
-    this.canvasStartPosition.x = x + scrollLeft;
-    this.canvasStartPosition.y = y + scrollTop;
+    this.canvasStartPosition.x = left + scrollLeft;
+    this.canvasStartPosition.y = top + scrollTop;
     const {ctx} = this;
     if (!ctx) throw new Error('ctx is null.');
     this.loadContextSetting(ctx);

--- a/src/components/actionLayer/MouseMoveActionLayer.js
+++ b/src/components/actionLayer/MouseMoveActionLayer.js
@@ -46,7 +46,12 @@ export default class MouseMoveActionLayer extends React.Component<
     if (!canvas) throw new Error('canvas is null.');
     this.ctx = canvas.getContext('2d');
     const {x, y} = ((canvas.getBoundingClientRect(): any): DOMRect);
-    this.canvasStartPosition = {x, y};
+    if (!document.scrollingElement) {
+      throw new Error('document.scrollingElement is undefined.');
+    }
+    const {scrollTop, scrollLeft} = (document.scrollingElement: any);
+    this.canvasStartPosition.x = x + scrollLeft;
+    this.canvasStartPosition.y = y + scrollTop;
     const {ctx} = this;
     if (!ctx) throw new Error('ctx is null.');
     this.loadContextSetting(ctx);


### PR DESCRIPTION
#112 の対応。
画面がスクロールした状態で`componentDidMount()`されると`canvasStartPosition`を正しく取得できなかったのが原因。
`document.scrollingElement`でスクロールした長さを取得し、それも加味するようにした。

`canvas.getBoundingClientRect`の返り値は、`x, y`ではなく`left, top`を使うようにした。
`x, y`はテスト環境では取得できなかったため。